### PR TITLE
 ARM: dts: qcom-msm8974pro-oneplus-bacon: Add NFC node

### DIFF
--- a/arch/arm/boot/dts/qcom/qcom-msm8974pro-oneplus-bacon.dts
+++ b/arch/arm/boot/dts/qcom/qcom-msm8974pro-oneplus-bacon.dts
@@ -180,6 +180,16 @@
 		interrupts-extended = <&tlmm 31 IRQ_TYPE_EDGE_FALLING>;
 		omit-battery-class;
 	};
+
+        nfc@28 {
+                compatible = "nxp,nxp-nci-i2c";
+                reg = <0x28>;
+
+                interrupts-extended = <&tlmm 59 IRQ_TYPE_EDGE_FALLING>;
+
+                enable-gpios = <&tlmm 14 GPIO_ACTIVE_HIGH>;
+                firmware-gpios = <&tlmm 13 GPIO_ACTIVE_HIGH>;
+        };
 };
 
 &blsp1_uart2 {


### PR DESCRIPTION
in downstream driver. they are also using `IRQ_TYPE_LEVEL_HIGH` for irq. should i swich back to it? or keep using `IRQ_TYPE_EDGE_FALLING` just like what `bq24196_charger` have? the device can work in both modes

https://github.com/LineageOS/android_kernel_oneplus_msm8974/blob/84bb8fee677f3d6b606e7c21efd34571cc4c818d/drivers/nfc/pn544-oppo_find7op.c#L536