### PR TITLE
ARM: dts: qcom: msm8974-sony-shinano: increase load on l21 for sdhc2

### DIFF
--- a/arch/arm/boot/dts/qcom/qcom-msm8974pro-sony-xperia-shinano-common.dtsi
+++ b/arch/arm/boot/dts/qcom/qcom-msm8974pro-sony-xperia-shinano-common.dtsi
@@ -380,6 +380,8 @@
 		pm8941_l21: l21 {
 			regulator-min-microvolt = <2950000>;
 			regulator-max-microvolt = <2950000>;
+			regulator-system-load = <500000>;
+			regulator-allow-set-load;
 			regulator-boot-on;
 		};
 


### PR DESCRIPTION
SD cards would exhibit errors similar to ones described in commit 27fe0fc...

This patch applies the same change to the regulator for sdhc2.

This seems to fix the problem.

