### PR TITLE
Add initial support for Sony Xperia Z Ultra (togari)

### DIFF
--- a/Documentation/devicetree/bindings/arm/qcom.yaml
+++ b/Documentation/devicetree/bindings/arm/qcom.yaml
@@ -177,6 +177,7 @@ properties:
               - samsung,hlte
               - sony,xperia-amami
               - sony,xperia-honami
+              - sony,xperia-togari
           - const: qcom,msm8974
 
       - items:

--- a/arch/arm/boot/dts/qcom/Makefile
+++ b/arch/arm/boot/dts/qcom/Makefile
@@ -42,6 +42,7 @@ dtb-$(CONFIG_ARCH_QCOM) += \
 	qcom-msm8974-lge-nexus5-hammerhead.dtb \
 	qcom-msm8974-sony-xperia-rhine-amami.dtb \
 	qcom-msm8974-sony-xperia-rhine-honami.dtb \
+	qcom-msm8974-sony-xperia-rhine-togari.dtb \
 	qcom-msm8974-sony-xperia-sirius.dtb \
 	qcom-msm8974pro-fairphone-fp2.dtb \
 	qcom-msm8974pro-htc-m8.dtb \

--- a/arch/arm/boot/dts/qcom/qcom-msm8974-sony-xperia-rhine-amami.dts
+++ b/arch/arm/boot/dts/qcom/qcom-msm8974-sony-xperia-rhine-amami.dts
@@ -5,6 +5,22 @@
 	model = "Sony Xperia Z1 Compact";
 	compatible = "sony,xperia-amami", "qcom,msm8974";
 	chassis-type = "handset";
+
+	gpio-keys {
+		key-camera-snapshot {
+			label = "camera_snapshot";
+			gpios = <&pm8941_gpios 3 GPIO_ACTIVE_LOW>;
+			linux,input-type = <1>;
+			linux,code = <KEY_CAMERA>;
+		};
+
+		key-camera-focus {
+			label = "camera_focus";
+			gpios = <&pm8941_gpios 4 GPIO_ACTIVE_LOW>;
+			linux,input-type = <1>;
+			linux,code = <KEY_CAMERA_FOCUS>;
+		};
+	};
 };
 
 &smbb {

--- a/arch/arm/boot/dts/qcom/qcom-msm8974-sony-xperia-rhine-honami.dts
+++ b/arch/arm/boot/dts/qcom/qcom-msm8974-sony-xperia-rhine-honami.dts
@@ -5,4 +5,20 @@
 	model = "Sony Xperia Z1";
 	compatible = "sony,xperia-honami", "qcom,msm8974";
 	chassis-type = "handset";
+
+	gpio-keys {
+		key-camera-snapshot {
+			label = "camera_snapshot";
+			gpios = <&pm8941_gpios 3 GPIO_ACTIVE_LOW>;
+			linux,input-type = <1>;
+			linux,code = <KEY_CAMERA>;
+		};
+
+		key-camera-focus {
+			label = "camera_focus";
+			gpios = <&pm8941_gpios 4 GPIO_ACTIVE_LOW>;
+			linux,input-type = <1>;
+			linux,code = <KEY_CAMERA_FOCUS>;
+		};
+	};
 };

--- a/arch/arm/boot/dts/qcom/qcom-msm8974-sony-xperia-rhine-togari.dts
+++ b/arch/arm/boot/dts/qcom/qcom-msm8974-sony-xperia-rhine-togari.dts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0
+#include "qcom-msm8974-sony-xperia-rhine.dtsi"
+
+/* Togari uses a different touchscreen compared to other rhine devices */
+
+/ {
+	model = "Sony Xperia Z Ultra";
+	compatible = "sony,xperia-togari", "qcom,msm8974";
+	chassis-type = "handset";
+};
+
+&blsp1_i2c2 {
+	status = "disabled";
+
+	clock-frequency = <355000>;
+	vdd-supply = <&pm8941_l22>;
+};
+
+&pm8941_l23 {
+	regulator-min-microvolt = <2600000>;
+	regulator-max-microvolt = <2600000>;
+};

--- a/arch/arm/boot/dts/qcom/qcom-msm8974-sony-xperia-rhine.dtsi
+++ b/arch/arm/boot/dts/qcom/qcom-msm8974-sony-xperia-rhine.dtsi
@@ -28,20 +28,6 @@
 			linux,code = <KEY_VOLUMEDOWN>;
 		};
 
-		key-camera-snapshot {
-			label = "camera_snapshot";
-			gpios = <&pm8941_gpios 3 GPIO_ACTIVE_LOW>;
-			linux,input-type = <1>;
-			linux,code = <KEY_CAMERA>;
-		};
-
-		key-camera-focus {
-			label = "camera_focus";
-			gpios = <&pm8941_gpios 4 GPIO_ACTIVE_LOW>;
-			linux,input-type = <1>;
-			linux,code = <KEY_CAMERA_FOCUS>;
-		};
-
 		key-volume-up {
 			label = "volume_up";
 			gpios = <&pm8941_gpios 5 GPIO_ACTIVE_LOW>;

--- a/arch/arm/boot/dts/qcom/qcom-msm8974-sony-xperia-rhine.dtsi
+++ b/arch/arm/boot/dts/qcom/qcom-msm8974-sony-xperia-rhine.dtsi
@@ -435,6 +435,7 @@
 	qcom,fast-charge-safe-current = <1500000>;
 	qcom,fast-charge-current-limit = <1500000>;
 	qcom,dc-current-limit = <1800000>;
+	usb-charge-current-limit = <1800000>;
 	qcom,fast-charge-safe-voltage = <4400000>;
 	qcom,fast-charge-high-threshold-voltage = <4350000>;
 	qcom,fast-charge-low-threshold-voltage = <3400000>;


### PR DESCRIPTION
Pretty much almost the same as honami and similar to amami. Only just getting it booting mainline kernel so not much is confirmed working other than volume button and usb networking on PMOS. Below are the dmesg for the booted device.

```dmesg
[    0.000000] Booting Linux on physical CPU 0x0
[    0.000000] Linux version 6.9.1 (pmos@nobara-main) (armv7-alpine-linux-musleabihf-gcc (Alpine 13.2.1_git20240309) 13.2.1 20240309, GNU ld (GNU Binutils) 2.42) #2-postmarketos-qcom-msm8974 SMP PREEMPT Sat Jul  6 13:00:34 UTC
[    0.000000] CPU: ARMv7 Processor [512f06f0] revision 0 (ARMv7), cr=10c5787d
[    0.000000] CPU: div instructions available: patching division code
[    0.000000] CPU: PIPT / VIPT nonaliasing data cache, PIPT instruction cache
[    0.000000] OF: fdt: Machine model: Sony Xperia Z Ultra
[    0.000000] Memory policy: Data cache writealloc
[    0.000000] OF: reserved mem: 0x08000000..0x0d0fffff (82944 KiB) nomap non-reusable mpss@8000000
[    0.000000] OF: reserved mem: 0x0d100000..0x0d1fffff (1024 KiB) nomap non-reusable mba@d100000
[    0.000000] OF: reserved mem: 0x0d200000..0x0dbfffff (10240 KiB) nomap non-reusable wcnss@d200000
[    0.000000] OF: reserved mem: 0x0dc00000..0x0f4fffff (25600 KiB) nomap non-reusable adsp@dc00000
[    0.000000] OF: reserved mem: 0x0f500000..0x0f9fffff (5120 KiB) nomap non-reusable memory@f500000
[    0.000000] OF: reserved mem: 0x0fa00000..0x0fbfffff (2048 KiB) nomap non-reusable smem@fa00000
[    0.000000] OF: reserved mem: 0x0fc00000..0x0fd5ffff (1408 KiB) nomap non-reusable memory@fc00000
[    0.000000] OF: reserved mem: 0x0fd60000..0x0fd7ffff (128 KiB) nomap non-reusable memory@fd60000
[    0.000000] OF: reserved mem: 0x0fd80000..0x0fefffff (1536 KiB) nomap non-reusable rmtfs@fd80000
[    0.000000] OF: reserved mem: 0x3e8e0000..0x3eadffff (2048 KiB) map non-reusable ramoops@3e8e0000
[    0.000000] cma: Reserved 256 MiB at 0x70000000 on node -1
[    0.000000] Zone ranges:
[    0.000000]   Normal   [mem 0x0000000000000000-0x000000002fffffff]
[    0.000000]   HighMem  [mem 0x0000000030000000-0x000000007fffffff]
[    0.000000] Movable zone start for each node
[    0.000000] Early memory node ranges
[    0.000000]   node   0: [mem 0x0000000000000000-0x0000000007ffffff]
[    0.000000]   node   0: [mem 0x0000000008000000-0x000000000fefffff]
[    0.000000]   node   0: [mem 0x000000000ff00000-0x000000007fffffff]
[    0.000000] Initmem setup node 0 [mem 0x0000000000000000-0x000000007fffffff]
[    0.000000] percpu: Embedded 19 pages/cpu s46612 r8192 d23020 u77824
[    0.000000] pcpu-alloc: s46612 r8192 d23020 u77824 alloc=19*4096
[    0.000000] pcpu-alloc: [0] 0 [0] 1 [0] 2 [0] 3
[    0.000000] Kernel command line: msm.vram=192m msm.allow_vram_carveout=1 androidboot.emmc=true androidboot.bootloader=s1 oemandroidboot.s1boot=1270-3115_S1_Boot_MSM8974_Rhine1.3.1_LA1.04_16 androidboot.serialno=EP7338CKSG ta_info=1,16,256 startup=0x00000004 warmboot=0x00000000 oemandroidboot.imei=3580800526044600 oemandroidboot.phoneid=0000:3580800526044600 oemandroidboot.security=0 oemandroidboot.securityflags=0x00000003 androidboot.baseband=msm
[    0.000000] Unknown kernel command line parameters "ta_info=1,16,256 startup=0x00000004 warmboot=0x00000000", will be passed to user space.
[    0.000000] Dentry cache hash table entries: 131072 (order: 7, 524288 bytes, linear)
[    0.000000] Inode-cache hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.000000] Built 1 zonelists, mobility grouping on.  Total pages: 522560
[    0.000000] mem auto-init: stack:off, heap alloc:off, heap free:off
[    0.000000] Memory: 1656964K/2097152K available (12288K kernel code, 1598K rwdata, 4744K rodata, 1024K init, 295K bss, 178044K reserved, 262144K cma-reserved, 1046528K highmem)
[    0.000000] SLUB: HWalign=64, Order=0-3, MinObjects=0, CPUs=4, Nodes=1
[    0.000000] trace event string verifier disabled
[    0.000000] rcu: Preemptible hierarchical RCU implementation.
[    0.000000]  Trampoline variant of Tasks RCU enabled.
[    0.000000]  Tracing variant of Tasks RCU enabled.
[    0.000000] rcu: RCU calculated value of scheduler-enlistment delay is 10 jiffies.
[    0.000000] RCU Tasks: Setting shift to 2 and lim to 1 rcu_task_cb_adjust=1.
[    0.000000] RCU Tasks Trace: Setting shift to 2 and lim to 1 rcu_task_cb_adjust=1.
[    0.000000] NR_IRQS: 16, nr_irqs: 16, preallocated irqs: 16
[    0.000000] rcu: srcu_init: Setting srcu_struct sizes based on contention.
[    0.000000] arch_timer: cp15 and mmio timer(s) running at 19.20MHz (virt/virt).
[    0.000000] clocksource: arch_sys_counter: mask: 0xffffffffffffff max_cycles: 0x46d987e47, max_idle_ns: 440795202767 ns
[    0.000001] sched_clock: 56 bits at 19MHz, resolution 52ns, wraps every 4398046511078ns
[    0.000016] Switching to timer-based delay loop, resolution 52ns
[    0.000230] Console: colour dummy device 80x30
[    0.000246] printk: legacy console [tty0] enabled
[    0.000957] Calibrating delay loop (skipped), value calculated using timer frequency.. 38.40 BogoMIPS (lpj=192000)
[    0.000998] CPU: Testing write buffer coherency: ok
[    0.001055] pid_max: default: 32768 minimum: 301
[    0.001249] Mount-cache hash table entries: 2048 (order: 1, 8192 bytes, linear)
[    0.001285] Mountpoint-cache hash table entries: 2048 (order: 1, 8192 bytes, linear)
[    0.002474] CPU0: thread -1, cpu 0, socket 0, mpidr 80000000
[    0.002519] qcom_scm: convention: smc legacy
[    0.004330] Setting up static identity map for 0x100000 - 0x100060
[    0.004577] rcu: Hierarchical SRCU implementation.
[    0.004600] rcu:     Max phase no-delay instances is 1000.
[    0.006230] smp: Bringing up secondary CPUs ...
[    0.007387] CPU1: thread -1, cpu 1, socket 0, mpidr 80000001
[    0.008838] CPU2: thread -1, cpu 2, socket 0, mpidr 80000002
[    0.010319] CPU3: thread -1, cpu 3, socket 0, mpidr 80000003
[    0.010611] smp: Brought up 1 node, 4 CPUs
[    0.010679] SMP: Total of 4 processors activated (153.60 BogoMIPS).
[    0.010705] CPU: All CPU(s) started in SVC mode.
[    0.012302] devtmpfs: initialized
[    0.030450] VFP support v0.3: implementor 51 architecture 64 part 6f variant 2 rev 0
[    0.030909] clocksource: jiffies: mask: 0xffffffff max_cycles: 0xffffffff, max_idle_ns: 19112604462750000 ns
[    0.030954] futex hash table entries: 1024 (order: 4, 65536 bytes, linear)
[    0.042845] pinctrl core: initialized pinctrl subsystem
[    0.044783] NET: Registered PF_NETLINK/PF_ROUTE protocol family
[    0.048121] DMA: preallocated 256 KiB pool for atomic coherent allocations
[    0.050050] thermal_sys: Registered thermal governor 'step_wise'
[    0.050213] cpuidle: using governor menu
[    0.050628] hw-breakpoint: Failed to enable monitor mode on CPU 0.
[    0.073060] platform f9a55000.usb: Fixed dependency cycle(s) with /soc/usb@f9a55000/ulpi/phy-0
[    0.073969] amba fc307000.etf: Fixed dependency cycle(s) with /soc/funnel@fc31b000
[    0.074034] amba fc307000.etf: Fixed dependency cycle(s) with /soc/replicator@fc31c000
[    0.074309] amba fc318000.tpiu: Fixed dependency cycle(s) with /soc/replicator@fc31c000
[    0.074560] amba fc31a000.funnel: Fixed dependency cycle(s) with /soc/funnel@fc31b000
[    0.074634] amba fc31a000.funnel: Fixed dependency cycle(s) with /soc/funnel@fc345000
[    0.074890] amba fc31a000.funnel: Fixed dependency cycle(s) with /soc/funnel@fc31b000
[    0.075073] amba fc307000.etf: Fixed dependency cycle(s) with /soc/funnel@fc31b000
[    0.075231] amba fc31b000.funnel: Fixed dependency cycle(s) with /soc/etf@fc307000
[    0.075400] amba fc31b000.funnel: Fixed dependency cycle(s) with /soc/funnel@fc31a000
[    0.075784] amba fc318000.tpiu: Fixed dependency cycle(s) with /soc/replicator@fc31c000
[    0.075936] amba fc307000.etf: Fixed dependency cycle(s) with /soc/replicator@fc31c000
[    0.076133] amba fc31c000.replicator: Fixed dependency cycle(s) with /soc/etf@fc307000
[    0.076274] amba fc31c000.replicator: Fixed dependency cycle(s) with /soc/tpiu@fc318000
[    0.076415] amba fc31c000.replicator: Fixed dependency cycle(s) with /soc/etr@fc322000
[    0.076644] amba fc31c000.replicator: Fixed dependency cycle(s) with /soc/etr@fc322000
[    0.076850] amba fc322000.etr: Fixed dependency cycle(s) with /soc/replicator@fc31c000
[    0.077211] amba fc33c000.etm: Fixed dependency cycle(s) with /soc/funnel@fc345000
[    0.077489] amba fc33d000.etm: Fixed dependency cycle(s) with /soc/funnel@fc345000
[    0.077760] amba fc33e000.etm: Fixed dependency cycle(s) with /soc/funnel@fc345000
[    0.078028] amba fc33f000.etm: Fixed dependency cycle(s) with /soc/funnel@fc345000
[    0.078318] amba fc33f000.etm: Fixed dependency cycle(s) with /soc/funnel@fc345000
[    0.078511] amba fc33e000.etm: Fixed dependency cycle(s) with /soc/funnel@fc345000
[    0.078703] amba fc33d000.etm: Fixed dependency cycle(s) with /soc/funnel@fc345000
[    0.078891] amba fc33c000.etm: Fixed dependency cycle(s) with /soc/funnel@fc345000
[    0.079058] amba fc31a000.funnel: Fixed dependency cycle(s) with /soc/funnel@fc345000
[    0.079226] amba fc345000.funnel: Fixed dependency cycle(s) with /soc/funnel@fc31a000
[    0.079375] amba fc345000.funnel: Fixed dependency cycle(s) with /soc/etm@fc33f000
[    0.079514] amba fc345000.funnel: Fixed dependency cycle(s) with /soc/etm@fc33e000
[    0.079663] amba fc345000.funnel: Fixed dependency cycle(s) with /soc/etm@fc33d000
[    0.079801] amba fc345000.funnel: Fixed dependency cycle(s) with /soc/etm@fc33c000
[    0.092980] kprobes: kprobe jump-optimization is enabled. All kprobes are optimized if possible.
[    0.103184] SCSI subsystem initialized
[    0.103546] libata version 3.00 loaded.
[    0.104051] usbcore: registered new interface driver usbfs
[    0.104162] usbcore: registered new interface driver hub
[    0.104268] usbcore: registered new device driver usb
[    0.105626] Advanced Linux Sound Architecture Driver Initialized.
[    0.107586] vgaarb: loaded
[    0.107997] clocksource: Switched to clocksource arch_sys_counter
[    0.130666] NET: Registered PF_INET protocol family
[    0.131041] IP idents hash table entries: 16384 (order: 5, 131072 bytes, linear)
[    0.133763] tcp_listen_portaddr_hash hash table entries: 512 (order: 0, 4096 bytes, linear)
[    0.133830] Table-perturb hash table entries: 65536 (order: 6, 262144 bytes, linear)
[    0.133884] TCP established hash table entries: 8192 (order: 3, 32768 bytes, linear)
[    0.133989] TCP bind hash table entries: 8192 (order: 5, 131072 bytes, linear)
[    0.134208] TCP: Hash tables configured (established 8192 bind 8192)
[    0.134353] UDP hash table entries: 512 (order: 2, 16384 bytes, linear)
[    0.134425] UDP-Lite hash table entries: 512 (order: 2, 16384 bytes, linear)
[    0.134671] NET: Registered PF_UNIX/PF_LOCAL protocol family
[    0.135517] RPC: Registered named UNIX socket transport module.
[    0.135558] RPC: Registered udp transport module.
[    0.135590] RPC: Registered tcp transport module.
[    0.135622] RPC: Registered tcp-with-tls transport module.
[    0.135654] RPC: Registered tcp NFSv4.1 backchannel transport module.
[    0.135701] PCI: CLS 0 bytes, default 64
[    0.137120] Trying to unpack rootfs image as initramfs...
[    0.148105] hw perfevents: enabled with armv7_krait PMU driver, 5 counters available
[    0.151183] Initialise system trusted keyrings
[    0.151589] workingset: timestamp_bits=14 max_order=19 bucket_order=5
[    0.153020] NFS: Registering the id_resolver key type
[    0.153091] Key type id_resolver registered
[    0.153127] Key type id_legacy registered
[    0.154843] Key type cifs.idmap registered
[    0.328692] Key type asymmetric registered
[    0.328745] Asymmetric key parser 'x509' registered
[    0.328959] bounce: pool size: 64 pages
[    0.329072] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 250)
[    0.329442] io scheduler mq-deadline registered
[    0.329481] io scheduler kyber registered
[    0.463183] msm_serial: driver initialized
[    0.489146] brd: module loaded
[    0.502983] loop: module loaded
[    0.503821] SCSI Media Changer driver v0.25
[    0.504888] spmi spmi-0: PMIC arbiter version v1 (0x20000002)
[    0.525673] qcom,wled fc4cf000.spmi:pm8941@1:wled@d800: error -ENXIO: IRQ ovp not found
[    0.526228] platform fc4cf000.spmi:pm8941@1:regulators: Fixed dependency cycle(s) with /soc/spmi@fc4cf000/pm8941@1/regulators/s4
[    0.530765] SLIP: version 0.8.4-NET3.019-NEWTTY (dynamic channels, max=256) (6 bit encapsulation enabled).
[    0.530818] CSLIP: code copyright 1989 Regents of the University of California.
[    0.534333] s4: Bringing 5100000uV into 5000000-5000000uV
[    0.538958] usbcore: registered new interface driver cdc_acm
[    0.539001] cdc_acm: USB Abstract Control Model driver for USB modems and ISDN adapters
[    0.549973] rtc-pm8xxx fc4cf000.spmi:pm8941@0:rtc@6000: registered as rtc0
[    0.550077] rtc-pm8xxx fc4cf000.spmi:pm8941@0:rtc@6000: setting system clock to 1970-01-01T12:54:18 UTC (46458)
[    0.550331] i2c_dev: i2c /dev entries driver
[    0.565723] device-mapper: ioctl: 4.48.0-ioctl (2023-03-01) initialised: dm-devel@lists.linux.dev
[    0.567186] sdhci: Secure Digital Host Controller Interface driver
[    0.567223] sdhci: Copyright(c) Pierre Ossman
[    0.567256] sdhci-pltfm: SDHCI platform and OF driver helper
[    0.570435] usbcore: registered new interface driver usbhid
[    0.570475] usbhid: USB HID core driver
[    0.580045] Initializing XFRM netlink socket
[    0.580193] NET: Registered PF_INET6 protocol family
[    0.582274] Freeing initrd memory: 5856K
[    0.582297] Segment Routing with IPv6
[    0.582418] In-situ OAM (IOAM) with IPv6
[    0.582573] NET: Registered PF_PACKET protocol family
[    0.582628] NET: Registered PF_KEY protocol family
[    0.582733] 8021q: 802.1Q VLAN Support v1.8
[    0.582861] Key type dns_resolver registered
[    0.583221] Registering SWP/SWPB emulation handler
[    0.607126] Timer migration: 1 hierarchy levels; 8 children per group; 1 crossnode level
[    0.607742] Loading compiled-in X.509 certificates
[    0.634284] qcom-rpm-proc remoteproc: Failed to create device link (0x180) with vreg-boost
[    0.642399] qcom-smbb fc4cf000.spmi:pm8941@0:charger@1000: Initializing SMBB rev 3
[    0.686183] input: gpio-keys as /devices/platform/gpio-keys/input/input0
[    0.722876] clk: Disabling unused clocks
[    0.722924] PM: genpd: Disabling unused power domains
[    0.722975] ALSA device list:
[    0.723020]   No soundcards found.
[    0.724621] Freeing unused kernel image (initmem) memory: 1024K
[    0.724844] Run /init as init process
[    0.724879]   with arguments:
[    0.724897]     /init
[    0.724912]   with environment:
[    0.724926]     HOME=/
[    0.724941]     TERM=linux
[    0.724955]     ta_info=1,16,256
[    0.724969]     startup=0x00000004
[    0.724983]     warmboot=0x00000000
[    0.843224] syslogd started: BusyBox v1.36.1
[    0.849660] [pmOS-rd]: Configuring kernel firmware image search path
[    0.858561] udevd[109]: starting version 3.2.14
[    0.866057] s1: Bringing 0uV into 1300000-1300000uV
[    0.866366] s1: Bringing 0uV into 675000-675000uV
[    0.867530] s2: Bringing 0uV into 2150000-2150000uV
[    0.868225] s2: Bringing 0uV into 500000-500000uV
[    0.868530] s3: Bringing 0uV into 1800000-1800000uV
[    0.868805] s3: Bringing 0uV into 500000-500000uV
[    0.869350] s4: Bringing 0uV into 500000-500000uV
[    0.869929] s4: Bringing 0uV into 5000000-5000000uV
[    0.870441] l1: Bringing 0uV into 1225000-1225000uV
[    0.871182] l2: Bringing 0uV into 1200000-1200000uV
[    0.871728] l3: Bringing 0uV into 1200000-1200000uV
[    0.872249] l4: Bringing 0uV into 1225000-1225000uV
[    0.872777] l5: Bringing 0uV into 1800000-1800000uV
[    0.873414] l6: Bringing 0uV into 1800000-1800000uV
[    0.874629] l7: Bringing 0uV into 1800000-1800000uV
[    0.875796] l8: Bringing 0uV into 1800000-1800000uV
[    0.876437] l9: Bringing 0uV into 1800000-1800000uV
[    0.876984] l11: Bringing 0uV into 1300000-1300000uV
[    0.877655] l12: Bringing 0uV into 1800000-1800000uV
[    0.878762] l13: Bringing 0uV into 1800000-1800000uV
[    0.879902] l14: Bringing 0uV into 1800000-1800000uV
[    0.880614] l15: Bringing 0uV into 2050000-2050000uV
[    0.881183] l16: Bringing 0uV into 2700000-2700000uV
[    0.881987] l17: Bringing 0uV into 2700000-2700000uV
[    0.882548] l18: Bringing 0uV into 2850000-2850000uV
[    0.883278] l19: Bringing 0uV into 3300000-3300000uV
[    0.884269] l20: Bringing 0uV into 2950000-2950000uV
[    0.885032] l21: Bringing 0uV into 2950000-2950000uV
[    0.886158] l22: Bringing 0uV into 3000000-3000000uV
[    0.886750] l23: Bringing 0uV into 2800000-2800000uV
[    0.887467] l24: Bringing 0uV into 3075000-3075000uV
[    0.946913] ocmem fdd00000.sram: 8 ports, 3 regions, 24 macros, interleaved
[    0.947545] msm_serial f991e000.serial: msm_serial: detected port #0
[    0.947659] msm_serial f991e000.serial: uartclk = 7372800
[    0.948268] f991e000.serial: ttyMSM0 at MMIO 0xf991e000 (irq = 60, base_baud = 460800) is a MSM
[    0.948343] msm_serial: console setup on port #0
[    0.948438] printk: legacy console [ttyMSM0] enabled
[    2.424978] i2c_qup f9924000.i2c:
                tx channel not available
[    2.427337] i2c_qup f9928000.i2c:
                tx channel not available
[    2.438477] sdhci_msm f98a4900.mmc: Got CD GPIO
[    2.478429] mmc0: SDHCI controller on f98a4900.mmc [f98a4900.mmc] using ADMA
[    2.488153] mmc1: SDHCI controller on f9824900.mmc [f9824900.mmc] using ADMA
[    2.518735] mmc0: new high speed SD card at address 0002
[    2.519743] mmcblk0: mmc0:0002 00000 1.87 GiB
[    2.526515]  mmcblk0: p1 p2
[    2.589283] mmc1: new HS200 MMC card at address 0001
[    2.590306] mmcblk1: mmc1:0001 MAG2GC 14.6 GiB
[    2.597371]  mmcblk1: p1 p2 p3 p4 p5 p6 p7 p8 p9 p10 p11 p12 p13 p14 p15 p16 p17 p18 p19 p20 p21 p22 p23 p24 p25
[    2.605521] mmcblk1boot0: mmc1:0001 MAG2GC 4.00 MiB
[    2.609975] mmcblk1boot1: mmc1:0001 MAG2GC 4.00 MiB
[    2.614472] mmcblk1rpmb: mmc1:0001 MAG2GC 4.00 MiB, chardev (244:0)
[    3.438089] random: crng init done
[    3.457143] udevd[134]: starting eudev-3.2.14
[    3.569767] udevd[146]: ctx=0xb6df1dc0 path=/lib/modules/6.9.1/kernel/drivers/input/rmi4/rmi_core.ko error=No such file or directory
[    3.915548] udevd[156]: failed to execute '/usr/libexec/elogind/elogind-uaccess-command' '/usr/libexec/elogind/elogind-uaccess-command /dev/rfkill ': No such file or directory
[    3.919973] udevd[159]: failed to execute '/usr/libexec/elogind/elogind-uaccess-command' '/usr/libexec/elogind/elogind-uaccess-command /dev/snd/timer ': No such file or directory
[    4.141190] udevd[146]: ctx=0xb6df1dc0 path=/lib/modules/6.9.1/kernel/drivers/input/rmi4/rmi_core.ko error=No such file or directory
[    4.159769] udevd[150]: ctx=0xb6df1dc0 path=/lib/modules/6.9.1/kernel/drivers/remoteproc/qcom_pil_info.ko error=No such file or directory
[    4.162060] udevd[139]: ctx=0xb6df1dc0 path=/lib/modules/6.9.1/kernel/drivers/remoteproc/qcom_pil_info.ko error=No such file or directory
[    4.203418] udevd[149]: ctx=0xb6df1dc0 path=/lib/modules/6.9.1/kernel/drivers/iio/adc/qcom-vadc-common.ko error=No such file or directory
[   11.370395] amba fc345000.funnel: deferred probe pending: (reason unknown)
[   11.370462] platform fc4cf000.spmi:pm8941@0:temp-alarm@2400: deferred probe pending: (reason unknown)
[   11.376196] amba fc307000.etf: deferred probe pending: (reason unknown)
[   11.385524] amba fc318000.tpiu: deferred probe pending: (reason unknown)
[   11.391945] amba fc31a000.funnel: deferred probe pending: (reason unknown)
[   11.398870] amba fc31b000.funnel: deferred probe pending: (reason unknown)
[   11.405528] amba fc31c000.replicator: deferred probe pending: (reason unknown)
[   11.412434] amba fc322000.etr: deferred probe pending: (reason unknown)
[   11.419615] amba fc33c000.etm: deferred probe pending: (reason unknown)
[   11.426099] amba fc33d000.etm: deferred probe pending: (reason unknown)
[   11.432739] amba fc33e000.etm: deferred probe pending: (reason unknown)
[   11.439318] amba fc33f000.etm: deferred probe pending: (reason unknown)
[   15.121967] [pmOS-rd]: ERROR: /dev/fb0 did not appear after waiting 10 seconds!
[   15.122060] [pmOS-rd]: If your device does not have a framebuffer, disable this with:
[   15.128202] [pmOS-rd]: no_framebuffer=true in <https://postmarketos.org/deviceinfo>
[   15.177361] [pmOS-rd]: Running initramfs hook: /hooks/00-msm-fb-refresher.sh
[   15.181660] [pmOS-rd]: tfb_acquire_fb() failed with error code: 1
[   15.184663] [pmOS-rd]: Assertion failed: fd >= 0 (refresher.c: main: 37)
[   15.189709] [pmOS-rd]: Setup usb network
[   15.196283] [pmOS-rd]:   /sys/class/android_usb does not exist, skipping android_usb
[   15.200240] [pmOS-rd]:   Setting up an USB gadget through configfs
[   15.226246] configfs-gadget.g1 gadget.0: HOST MAC 1a:22:b3:96:51:af
[   15.226300] configfs-gadget.g1 gadget.0: MAC 0a:ed:a2:ad:d9:cf
[   15.231567] l24: voltage operation not allowed
[   15.262012] [pmOS-rd]: Starting unudhcpd with server ip 172.16.42.1, client ip: 172.16.42.2
[   15.279253] [pmOS-rd]:   Using interface usb0
[   15.279329] [pmOS-rd]:   Starting the DHCP daemon
[   15.282755] [pmOS-rd]: Trying to start server with parameters: Server IP addr: 172.16.42.1:67, client IP addr: 172.16.42.2, interface: usb0
[   16.298768] [pmOS-rd]: Trying to mount subpartitions for 10 seconds...
[   18.585408] [pmOS-rd]: /dev/mmcblk0p1
[   18.593116] [pmOS-rd]: Mount boot partition (/dev/mmcblk0p1) to /boot (read-only)
[   18.604253] [pmOS-rd]: Detected ext filesystem
[   18.626984] EXT4-fs (mmcblk0p1): mounted filesystem 5fc07d0e-76ec-4187-a620-00ad979254f8 ro without journal. Quota mode: disabled.
[   18.634196] [pmOS-rd]: Extract /boot/initramfs-extra
[   18.909853] [pmOS-rd]: 5267 blocks
[   18.915311] [pmOS-rd]: ls: /hooks-extra: No such file or directory
[   19.538429] [pmOS-rd]: /dev/mmcblk0p2
[   20.027132] [pmOS-rd]: Unable to resize root partition: failed to find qualifying partition
[   20.040664] [pmOS-rd]: Mount root partition (/dev/mmcblk0p2) to /sysroot (read-only) with options
[   20.051275] [pmOS-rd]: Detected ext4 filesystem
[   20.388324] EXT4-fs (mmcblk0p2): orphan cleanup on readonly fs
[   20.389123] EXT4-fs (mmcblk0p2): mounted filesystem 2f93b6e0-00aa-44ab-ad95-9ea4802068af ro with ordered data mode. Quota mode: disabled.
[   20.424868] EXT4-fs (mmcblk0p1): unmounting filesystem 5fc07d0e-76ec-4187-a620-00ad979254f8.
[   20.435602] [pmOS-rd]: Mount boot partition (/dev/mmcblk0p1) to /sysroot/boot (read-write)
[   20.445992] [pmOS-rd]: Detected ext filesystem
[   20.607020] EXT4-fs (mmcblk0p1): mounted filesystem 5fc07d0e-76ec-4187-a620-00ad979254f8 r/w without journal. Quota mode: disabled.
[   20.618444] [pmOS-rd]: Running initramfs hook: /hooks-cleanup/msm-fb-refresher-cleanup.sh
[   20.622613] [pmOS-rd]: sh: can't kill pid 274: No such process
[   20.626245] [pmOS-rd]: Switching root
[   20.718119] syslogd exiting
[   23.870427] udevd[699]: starting version 3.2.14
[   24.154403] udevd[699]: starting eudev-3.2.14
[   24.498211] rmi4_i2c 0-002c: rmi_set_page: set page failed: -6.
[   24.498239] rmi4_i2c 0-002c: Failed to set page select to 0
[   24.616363] input: pm8941_pwrkey as /devices/platform/soc/fc4cf000.spmi/spmi-0/0-00/fc4cf000.spmi:pm8941@0:pon@800/fc4cf000.spmi:pm8941@0:pon@800:pwrkey/input/input1
[   24.756382] remoteproc remoteproc0: fe200000.remoteproc is available
[   24.785438] remoteproc remoteproc1: fc880000.remoteproc is available
[   24.792012] remoteproc remoteproc0: Direct firmware load for adsp.mdt failed with error -2
[   24.792047] remoteproc remoteproc0: powering up fe200000.remoteproc
[   24.792141] remoteproc remoteproc0: Direct firmware load for adsp.mdt failed with error -2
[   24.792166] remoteproc remoteproc0: request_firmware failed: -2
[   27.905262] EXT4-fs (mmcblk0p2): re-mounted 2f93b6e0-00aa-44ab-ad95-9ea4802068af r/w. Quota mode: disabled.
[   28.018176] EXT4-fs (mmcblk0p2): re-mounted 2f93b6e0-00aa-44ab-ad95-9ea4802068af r/w. Quota mode: disabled.
[   28.198614] EXT4-fs (mmcblk0p1): re-mounted 5fc07d0e-76ec-4187-a620-00ad979254f8 r/w. Quota mode: disabled.
[   30.814921] Bluetooth: Core ver 2.22
[   30.815018] NET: Registered PF_BLUETOOTH protocol family
[   30.815033] Bluetooth: HCI device and connection manager initialized
[   30.815057] Bluetooth: HCI socket layer initialized
[   30.815080] Bluetooth: L2CAP socket layer initialized
[   30.815115] Bluetooth: SCO socket layer initialized
[   30.895837] Bluetooth: BNEP (Ethernet Emulation) ver 1.3
[   30.895864] Bluetooth: BNEP filters: protocol multicast
[   30.895890] Bluetooth: BNEP socket layer initialized
[   31.200037] l7: disabling
[   38.030095] l24: voltage operation not allowed
[   46.201549] zram: Added device: zram0

```