### PR TITLE
ARM: dts: qcom: msm8974-samsung-hlte: Add touchkey support

### DIFF
--- a/arch/arm/boot/dts/qcom/qcom-msm8974-samsung-hlte.dts
+++ b/arch/arm/boot/dts/qcom/qcom-msm8974-samsung-hlte.dts
@@ -50,6 +50,34 @@
 		};
 	};
 
+	i2c-gpio-touchkey {
+		compatible = "i2c-gpio";
+
+		sda-gpios = <&tlmm 95 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&tlmm 96 (GPIO_ACTIVE_HIGH | GPIO_OPEN_DRAIN)>;
+
+		pinctrl-0 = <&i2c_touchkey_pins>;
+		pinctrl-names = "default";
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		touchkey@20 {
+			compatible = "cypress,midas-touchkey";
+			reg = <0x20>;
+
+			interrupts-extended = <&pm8941_gpios 29 IRQ_TYPE_EDGE_FALLING>;
+
+			pinctrl-0 = <&touchkey_pin>;
+			pinctrl-names = "default";
+
+			vcc-supply = <&pm8941_lvs3>;
+			vdd-supply = <&pm8941_l13>;
+
+			linux,keycodes = <KEY_APPSELECT KEY_BACK>;
+		};
+	};
+
 	vreg_panel: regulator-panel {
 		compatible = "regulator-fixed";
 		regulator-name = "panel-vddr-reg";
@@ -206,6 +234,14 @@
 		output-high;
 		power-source = <PM8941_GPIO_S3>;
 		qcom,drive-strength = <PMIC_GPIO_STRENGTH_HIGH>;
+	};
+
+	touchkey_pin: touchkey-int-state {
+		pins = "gpio29";
+		function = "normal";
+		bias-disable;
+		input-enable;
+		power-source = <PM8941_GPIO_S3>;
 	};
 
 	panel_en_pin: panel-en-state {
@@ -394,6 +430,9 @@
 			regulator-min-microvolt = <3075000>;
 			regulator-max-microvolt = <3075000>;
 		};
+
+		pm8941_lvs1: lvs1 {};
+		pm8941_lvs3: lvs3 {};
 	};
 };
 
@@ -446,6 +485,12 @@
 		function = "mdp_vsync";
 		drive-strength = <2>;
 		bias-disable;
+	};
+
+	i2c_touchkey_pins: i2c-touchkey-state {
+		pins = "gpio95", "gpio96";
+		function = "gpio";
+		bias-pull-up;
 	};
 };
 


### PR DESCRIPTION
This adds support for the touchkeys on the Samsung Galaxy Note 3 (hlte).  The relevant sections were copied from the Samsung Galaxy S5 (klte) dts and tweaked based on pin information from the downstream LineageOS msm8974 kernel.  The Note 3's touchkey controller seems to use the register layout "midas-touchkey" as the default "tm2-touchkey" register layout always reads 0 when a key is pressed, leading to no input events being generated.  Also tested that the LEDs on the touchkeys can be turned on and off using /sys/class/leds/tm2-touchkey/brightness.