### PR TITLE
ARM: dts: qcom: msm8974-samsung-lt03lte: set i2c clk speed and add i2c touchscreen

### DIFF
--- a/arch/arm/boot/dts/qcom/qcom-msm8974-samsung-lt03lte.dts
+++ b/arch/arm/boot/dts/qcom/qcom-msm8974-samsung-lt03lte.dts
@@ -13,6 +13,62 @@
 		mmc0 = &sdhc_1; /* SDC1 eMMC slot */
 		mmc1 = &sdhc_3; /* SDC3 SD card slot */
 	};
+
+	tsp_sw3_2v8: regulator-tsp-sw3-2v8 {
+		compatible = "regulator-fixed";
+		regulator-name = "tsp_sw3_2v8";
+		regulator-min-microvolt = <2800000>;
+		regulator-max-microvolt = <2800000>;
+
+		gpio = <&pm8941_gpios 23 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-boot-on;
+
+		startup-delay-us = <1000>;
+		off-on-delay-us = <3000>;
+
+		pinctrl-0 = <&touch_en_pin_1>;
+		pinctrl-names = "default";
+	};
+
+	touch_avdd_2v8: regulator-touch-avdd-2v8 {
+		compatible = "regulator-fixed";
+		regulator-name = "touch_avdd_2v8";
+		regulator-min-microvolt = <2800000>;
+		regulator-max-microvolt = <2800000>;
+
+		gpio = <&pm8941_gpios 10 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		regulator-boot-on;
+
+		startup-delay-us = <30000>;
+		off-on-delay-us = <3000>;
+
+		pinctrl-0 = <&touch_en_pin>;
+		pinctrl-names = "default";
+
+		vin-supply = <&tsp_sw3_2v8>; /* tsp_sw3_2v8 must be enabled first before AVDD */
+	};
+};
+
+&blsp1_i2c2 {
+	clock-frequency = <400000>;
+
+	status = "okay";
+
+	touchscreen@4a {
+		compatible = "atmel,maxtouch";
+		reg = <0x4a>;
+
+		interrupts-extended = <&pm8941_gpios 30 IRQ_TYPE_EDGE_FALLING>;
+
+		pinctrl-0 = <&touch_rst_pin &touch_int_pin>;
+		pinctrl-names = "default";
+
+		reset-gpios = <&pm8941_gpios 9 GPIO_ACTIVE_LOW>;
+		vdda-supply = <&touch_avdd_2v8>;
+		vdd-supply = <&pm8941_l10>;
+	};
 };
 
 &blsp2_i2c6 {
@@ -258,6 +314,38 @@
 &pm8941_gpios {
 	fuelgauge_pin: fuelgauge-int-state {
 		pins = "gpio26";
+		function = "normal";
+		bias-disable;
+		input-enable;
+		power-source = <PM8941_GPIO_S3>;
+	};
+
+	touch_en_pin: touchscreen-en-state {
+		pins = "gpio10";
+		function = "normal";
+		bias-disable;
+		output-enable;
+		power-source = <PM8941_GPIO_S3>;
+	};
+
+	touch_en_pin_1: touchscreen-en-1-state {
+		pins = "gpio23";
+		function = "normal";
+		bias-disable;
+		output-enable;
+		power-source = <PM8941_GPIO_S3>;
+	};
+
+	touch_rst_pin: touchscreen-rst-state {
+		pins = "gpio9";
+		function = "normal";
+		bias-disable;
+		output-enable;
+		power-source = <PM8941_GPIO_S3>;
+	};
+
+	touch_int_pin: touchscreen-int-state {
+		pins = "gpio30";
 		function = "normal";
 		bias-disable;
 		input-enable;

--- a/arch/arm/boot/dts/qcom/qcom-msm8974-samsung-lt03lte.dts
+++ b/arch/arm/boot/dts/qcom/qcom-msm8974-samsung-lt03lte.dts
@@ -16,6 +16,8 @@
 };
 
 &blsp2_i2c6 {
+	clock-frequency = <400000>;
+
 	status = "okay";
 
 	fuelgauge@36 {


### PR DESCRIPTION
- Sets the i2c clock speed to 400KHz as per downstream DTS.
- Enable the i2c touchscreen.