### PR TITLE
ARM: dts: qcom: msm8974-samsung-lt03lte: Fuelgauge interrupts and i2c sensors

### DIFF
--- a/Documentation/devicetree/bindings/iio/gyroscope/bosch,bmg160.yaml
+++ b/Documentation/devicetree/bindings/iio/gyroscope/bosch,bmg160.yaml
@@ -22,6 +22,9 @@ properties:
   vdd-supply: true
   vddio-supply: true
 
+  mount-matrix:
+    description: an optional 3x3 mounting rotation matrix.
+
   spi-max-frequency:
     maximum: 10000000
 

--- a/Documentation/devicetree/bindings/iio/light/capella,cm3323.yaml
+++ b/Documentation/devicetree/bindings/iio/light/capella,cm3323.yaml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: (GPL-2.0 OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/iio/light/capella,cm3323.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title:
+  Capella Microsystems CM3323 Ambient Light Sensor
+
+description: |
+  The CM3323 is a color sensor used in mobile devices as an ambient light sensor.
+
+properties:
+  compatible:
+    const: capella,cm3323
+
+  reg:
+    maxItems: 1
+
+  vdd-supply: true
+
+required:
+  - compatible
+  - reg
+
+additionalProperties: false
+
+examples:
+  - |
+    light-sensor@10 {
+        compatible = "capella,cm3323";
+        reg = <0x10>;
+
+        vdd-supply = <&foo_reg>;
+    };
+...

--- a/Documentation/devicetree/bindings/trivial-devices.yaml
+++ b/Documentation/devicetree/bindings/trivial-devices.yaml
@@ -59,8 +59,6 @@ properties:
           - capella,cm32181
             # CM3232: Ambient Light Sensor
           - capella,cm3232
-            # CM3323: Ambient Light Sensor
-          - capella,cm3323
             # Cisco SPI Petra
           - cisco,spi-petra
             # High-Precision Digital Thermometer

--- a/arch/arm/boot/dts/qcom/qcom-msm8974-samsung-lt03lte.dts
+++ b/arch/arm/boot/dts/qcom/qcom-msm8974-samsung-lt03lte.dts
@@ -80,8 +80,7 @@
 		compatible = "maxim,max17050";
 		reg = <0x36>;
 
-		interrupt-parent = <&pm8941_gpios>;
-		interrupts = <26 IRQ_TYPE_EDGE_FALLING>;
+		interrupts-extended = <&pm8941_gpios 26 IRQ_TYPE_EDGE_FALLING>;
 
 		pinctrl-0 = <&fuelgauge_pin>;
 		pinctrl-names = "default";

--- a/arch/arm/boot/dts/qcom/qcom-msm8974-samsung-lt03lte.dts
+++ b/arch/arm/boot/dts/qcom/qcom-msm8974-samsung-lt03lte.dts
@@ -133,6 +133,24 @@
 			       "-1", "0", "0",
 			       "0", "0", "1";
 	};
+
+	gyroscope@68 {
+		compatible = "bosch,bmi055_gyro";
+		reg = <0x68>;
+
+		interrupts-extended = <&tlmm 74 IRQ_TYPE_EDGE_RISING>,
+				      <&tlmm 89 IRQ_TYPE_EDGE_RISING>;
+
+		vdd-supply = <&pm8941_l18>;
+		vddio-supply = <&pm8941_lvs1>;
+
+		pinctrl-0 = <&gyroscope_default_state>;
+		pinctrl-names = "default";
+
+		mount-matrix = "0", "-1", "0",
+			       "-1", "0", "0",
+			       "0", "0", "1";
+	};
 };
 
 &usb {
@@ -439,5 +457,21 @@
 		function = "gpio";
 		drive-strength = <2>;
 		bias-disable;
+	};
+
+	gyroscope_default_state: gyroscope-default-state {
+		int-pins {
+			pins = "gpio74";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-disable;
+		};
+
+		data-rdy-pins {
+			pins = "gpio89";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-disable;
+		};
 	};
 };

--- a/arch/arm/boot/dts/qcom/qcom-msm8974-samsung-lt03lte.dts
+++ b/arch/arm/boot/dts/qcom/qcom-msm8974-samsung-lt03lte.dts
@@ -91,6 +91,50 @@
 	};
 };
 
+&blsp2_i2c5 {
+	clock-frequency = <375000>;
+
+	status = "okay";
+
+	magnetometer@c {
+		compatible = "asahi-kasei,ak8963";
+		reg = <0x0c>;
+
+		interrupts-extended = <&tlmm 82 IRQ_TYPE_EDGE_RISING>;
+
+		vdd-supply = <&pm8941_l18>;
+		vid-supply = <&pm8941_lvs1>;
+
+		pinctrl-0 = <&magnetometer_default_state>;
+		pinctrl-names = "default";
+
+		reset-gpios = <&tlmm 81 GPIO_ACTIVE_LOW>;
+
+		mount-matrix = "1", "0", "0",
+			       "0", "-1", "0",
+			       "0", "0", "-1";
+	};
+
+	accelerometer@18 {
+		compatible = "bosch,bmi055_accel";
+		reg = <0x18>;
+
+		interrupts-extended = <&tlmm 86 IRQ_TYPE_EDGE_RISING>,
+				      <&tlmm 49 IRQ_TYPE_EDGE_RISING>;
+		interrupt-names = "INT1", "INT2";
+
+		vdd-supply = <&pm8941_l18>;
+		vddio-supply = <&pm8941_lvs1>;
+
+		pinctrl-0 = <&accelerometer_int_state>;
+		pinctrl-names = "default";
+
+		mount-matrix = "0", "-1", "0",
+			       "-1", "0", "0",
+			       "0", "0", "1";
+	};
+};
+
 &usb {
 	phys = <&usb_hs1_phy>;
 	phy-select = <&tcsr 0xb000 0>;
@@ -371,6 +415,29 @@
 		pins = "gpio35", "gpio36", "gpio37", "gpio38", "gpio39", "gpio40";
 		function = "sdc3";
 		drive-strength = <8>;
+		bias-disable;
+	};
+
+	magnetometer_default_state: magnetometer-default-state {
+		int-pins {
+			pins = "gpio82";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-disable;
+		};
+
+		reset-pins {
+			pins = "gpio81";
+			function = "gpio";
+			drive-strength = <2>;
+			bias-disable;
+		};
+	};
+
+	accelerometer_int_state: accelerometer-int-state {
+		pins = "gpio49", "gpio86";
+		function = "gpio";
+		drive-strength = <2>;
 		bias-disable;
 	};
 };

--- a/arch/arm/boot/dts/qcom/qcom-msm8974-samsung-lt03lte.dts
+++ b/arch/arm/boot/dts/qcom/qcom-msm8974-samsung-lt03lte.dts
@@ -115,6 +115,13 @@
 			       "0", "0", "-1";
 	};
 
+	light-sensor@10 {
+		compatible = "capella,cm3323";
+		reg = <0x10>;
+
+		vdd-supply = <&pm8941_l18>;
+	};
+
 	accelerometer@18 {
 		compatible = "bosch,bmi055_accel";
 		reg = <0x18>;

--- a/drivers/iio/light/cm3323.c
+++ b/drivers/iio/light/cm3323.c
@@ -9,6 +9,7 @@
  * TODO: calibscale to correct the lens factor
  */
 #include <linux/module.h>
+#include <linux/delay.h>
 #include <linux/init.h>
 #include <linux/i2c.h>
 #include <linux/mutex.h>
@@ -216,13 +217,20 @@ static const struct iio_info cm3323_info = {
 
 static int cm3323_probe(struct i2c_client *client)
 {
+	struct device *dev = &client->dev;
 	struct cm3323_data *data;
 	struct iio_dev *indio_dev;
 	int ret;
 
-	indio_dev = devm_iio_device_alloc(&client->dev, sizeof(*data));
+	indio_dev = devm_iio_device_alloc(dev, sizeof(*data));
 	if (!indio_dev)
 		return -ENOMEM;
+
+	ret = devm_regulator_get_enable(dev, "vdd");
+	if (ret < 0)
+		return dev_err_probe(dev, ret, "Failed to enable vdd supply\n");
+
+	fsleep(50000);
 
 	data = iio_priv(indio_dev);
 	i2c_set_clientdata(client, indio_dev);
@@ -238,15 +246,15 @@ static int cm3323_probe(struct i2c_client *client)
 
 	ret = cm3323_init(indio_dev);
 	if (ret < 0) {
-		dev_err(&client->dev, "cm3323 chip init failed\n");
+		dev_err(dev, "cm3323 chip init failed\n");
 		return ret;
 	}
 
-	ret = devm_add_action_or_reset(&client->dev, cm3323_disable, indio_dev);
+	ret = devm_add_action_or_reset(dev, cm3323_disable, indio_dev);
 	if (ret < 0)
 		return ret;
 
-	return devm_iio_device_register(&client->dev, indio_dev);
+	return devm_iio_device_register(dev, indio_dev);
 }
 
 static const struct i2c_device_id cm3323_id[] = {


### PR DESCRIPTION
- Use interrupts-extended for fuel-gauge
- Enables the following i2c sensors for samsung-lt03lte: Accelerometer, Gyro, Magnetometer, and Ambient Light sensor.