### PR TITLE
ARM: dts: qcom: msm8974-samsung-lt03lte: enable gpio keys

### DIFF
--- a/arch/arm/boot/dts/qcom/qcom-msm8974-samsung-lt03lte.dts
+++ b/arch/arm/boot/dts/qcom/qcom-msm8974-samsung-lt03lte.dts
@@ -2,6 +2,7 @@
 #include "qcom-msm8974.dtsi"
 #include "pm8841.dtsi"
 #include "pm8941.dtsi"
+#include <dt-bindings/input/input.h>
 #include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
 
 / {
@@ -12,6 +13,35 @@
 	aliases {
 		mmc0 = &sdhc_1; /* SDC1 eMMC slot */
 		mmc1 = &sdhc_3; /* SDC3 SD card slot */
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		pinctrl-0 = <&gpio_keys_active_pin>;
+		pinctrl-names = "default";
+
+		key-home {
+			label = "Home Key";
+			gpios = <&pm8941_gpios 3 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_HOMEPAGE>;
+			debounce-interval = <15>;
+			wakeup-source;
+		};
+
+		key-volume-down {
+			label = "Volume Down";
+			gpios = <&pm8941_gpios 2 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_VOLUMEDOWN>;
+			debounce-interval = <15>;
+		};
+
+		key-volume-up {
+			label = "Volume Up";
+			gpios = <&pm8941_gpios 5 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_VOLUMEUP>;
+			debounce-interval = <15>;
+		};
 	};
 
 	tsp_sw3_2v8: regulator-tsp-sw3-2v8 {
@@ -380,6 +410,13 @@
 };
 
 &pm8941_gpios {
+	gpio_keys_active_pin: gpio-keys-active-state {
+		pins = "gpio2", "gpio3", "gpio5";
+		function = "normal";
+		bias-pull-up;
+		power-source = <PM8941_GPIO_S3>;
+	};
+
 	fuelgauge_pin: fuelgauge-int-state {
 		pins = "gpio26";
 		function = "normal";


### PR DESCRIPTION
Enables the following GPIO input keys for msm8974-samsung-lt03lte:
- Volume Up
- Volume Down
- Physical Home Key